### PR TITLE
Fix missing mkdocs-sitemap-plugin dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,6 +6,7 @@ mkdocs-material>=9.4.0
 mkdocs-minify-plugin>=0.7.0
 mkdocs-git-revision-date-localized-plugin>=1.2.0
 pymdown-extensions>=10.0.0
+mkdocs-sitemap-plugin>=1.0.0
 
 # Required for the ESO Logs Python package itself
 requests>=2.25.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ docs = [
     "mkdocs-minify-plugin>=0.7.0",
     "mkdocs-git-revision-date-localized-plugin>=1.2.0",
     "pymdown-extensions>=10.0.0",
+    "mkdocs-sitemap-plugin>=1.0.0",
 ]
 all = [
     "esologs-python[dev,websockets,pandas,docs]",


### PR DESCRIPTION
## Summary
Fixes the ReadTheDocs build failure by adding the missing mkdocs-sitemap-plugin dependency.

## Problem
After PR #21 added the sitemap plugin to mkdocs.yml, ReadTheDocs builds started failing with:
```
ERROR   -  Config value 'plugins': The "sitemap" plugin is not installed
```

## Solution
- Added `mkdocs-sitemap-plugin>=1.0.0` to `docs/requirements.txt` (used by ReadTheDocs)
- Added the same dependency to `pyproject.toml` docs extras for local development consistency

## Test Plan
- [x] Dependency added to both files
- [x] Pre-commit hooks pass
- [ ] ReadTheDocs build should succeed after merge

This is a critical fix needed to restore documentation builds.