### PR TITLE
Add OAuth2 user authentication and UserData API methods

### DIFF
--- a/esologs/__init__.py
+++ b/esologs/__init__.py
@@ -73,6 +73,17 @@ from ._generated.get_classes import (
     GetClassesGameData,
     GetClassesGameDataClasses,
 )
+from ._generated.get_current_user import (
+    GetCurrentUser,
+    GetCurrentUserUserData,
+    GetCurrentUserUserDataCurrentUser,
+    GetCurrentUserUserDataCurrentUserCharacters,
+    GetCurrentUserUserDataCurrentUserCharactersServer,
+    GetCurrentUserUserDataCurrentUserCharactersServerRegion,
+    GetCurrentUserUserDataCurrentUserGuilds,
+    GetCurrentUserUserDataCurrentUserGuildsServer,
+    GetCurrentUserUserDataCurrentUserGuildsServerRegion,
+)
 from ._generated.get_encounters_by_zone import (
     GetEncountersByZone,
     GetEncountersByZoneWorldData,
@@ -218,6 +229,22 @@ from ._generated.get_reports import (
     GetReportsReportDataReportsDataOwner,
     GetReportsReportDataReportsDataZone,
 )
+from ._generated.get_user_by_id import (
+    GetUserById,
+    GetUserByIdUserData,
+    GetUserByIdUserDataUser,
+    GetUserByIdUserDataUserCharacters,
+    GetUserByIdUserDataUserCharactersServer,
+    GetUserByIdUserDataUserCharactersServerRegion,
+    GetUserByIdUserDataUserGuilds,
+    GetUserByIdUserDataUserGuildsServer,
+    GetUserByIdUserDataUserGuildsServerRegion,
+)
+from ._generated.get_user_data import (
+    GetUserData,
+    GetUserDataUserData,
+    GetUserDataUserDataUser,
+)
 from ._generated.get_world_data import (
     GetWorldData,
     GetWorldDataWorldData,
@@ -249,13 +276,25 @@ from ._generated.get_zones import (
     GetZonesWorldDataZonesEncounters,
     GetZonesWorldDataZonesExpansion,
 )
+from .auth import get_access_token
 from .client import Client
+from .user_auth import (
+    UserToken,
+    exchange_authorization_code,
+    generate_authorization_url,
+    refresh_access_token,
+)
 
 __all__ = [
     "AsyncBaseClient",
     "BaseModel",
     "CharacterRankingMetricType",
     "Client",
+    "UserToken",
+    "exchange_authorization_code",
+    "generate_authorization_url",
+    "get_access_token",
+    "refresh_access_token",
     "EventDataType",
     "ExternalBuffRankFilter",
     "FightRankingMetricType",
@@ -292,6 +331,15 @@ __all__ = [
     "GetClasses",
     "GetClassesGameData",
     "GetClassesGameDataClasses",
+    "GetCurrentUser",
+    "GetCurrentUserUserData",
+    "GetCurrentUserUserDataCurrentUser",
+    "GetCurrentUserUserDataCurrentUserCharacters",
+    "GetCurrentUserUserDataCurrentUserCharactersServer",
+    "GetCurrentUserUserDataCurrentUserCharactersServerRegion",
+    "GetCurrentUserUserDataCurrentUserGuilds",
+    "GetCurrentUserUserDataCurrentUserGuildsServer",
+    "GetCurrentUserUserDataCurrentUserGuildsServerRegion",
     "GetEncountersByZone",
     "GetEncountersByZoneWorldData",
     "GetEncountersByZoneWorldDataZone",
@@ -399,6 +447,18 @@ __all__ = [
     "GetReportsReportDataReportsDataGuildServerRegion",
     "GetReportsReportDataReportsDataOwner",
     "GetReportsReportDataReportsDataZone",
+    "GetUserById",
+    "GetUserByIdUserData",
+    "GetUserByIdUserDataUser",
+    "GetUserByIdUserDataUserCharacters",
+    "GetUserByIdUserDataUserCharactersServer",
+    "GetUserByIdUserDataUserCharactersServerRegion",
+    "GetUserByIdUserDataUserGuilds",
+    "GetUserByIdUserDataUserGuildsServer",
+    "GetUserByIdUserDataUserGuildsServerRegion",
+    "GetUserData",
+    "GetUserDataUserData",
+    "GetUserDataUserDataUser",
     "GetWorldData",
     "GetWorldDataWorldData",
     "GetWorldDataWorldDataEncounter",

--- a/esologs/_generated/generated_client.py
+++ b/esologs/_generated/generated_client.py
@@ -24,6 +24,7 @@ from .get_character_reports import GetCharacterReports
 from .get_character_zone_rankings import GetCharacterZoneRankings
 from .get_class import GetClass
 from .get_classes import GetClasses
+from .get_current_user import GetCurrentUser
 from .get_encounters_by_zone import GetEncountersByZone
 from .get_factions import GetFactions
 from .get_guild_attendance import GetGuildAttendance
@@ -49,6 +50,8 @@ from .get_report_player_details import GetReportPlayerDetails
 from .get_report_rankings import GetReportRankings
 from .get_report_table import GetReportTable
 from .get_reports import GetReports
+from .get_user_by_id import GetUserById
+from .get_user_data import GetUserData
 from .get_world_data import GetWorldData
 from .get_zones import GetZones
 
@@ -1664,3 +1667,114 @@ class Client(AsyncBaseClient):
         )
         data = self.get_data(response)
         return GetProgressRace.model_validate(data)
+
+    async def get_user_by_id(self, user_id: int, **kwargs: Any) -> GetUserById:
+        query = gql(
+            """
+            query getUserById($userId: Int!) {
+              userData {
+                user(id: $userId) {
+                  id
+                  name
+                  guilds {
+                    id
+                    name
+                    server {
+                      name
+                      region {
+                        name
+                      }
+                    }
+                  }
+                  characters {
+                    id
+                    name
+                    server {
+                      name
+                      region {
+                        name
+                      }
+                    }
+                    gameData
+                    classID
+                    raceID
+                    hidden
+                  }
+                  naDisplayName
+                  euDisplayName
+                }
+              }
+            }
+            """
+        )
+        variables: Dict[str, object] = {"userId": user_id}
+        response = await self.execute(
+            query=query, operation_name="getUserById", variables=variables, **kwargs
+        )
+        data = self.get_data(response)
+        return GetUserById.model_validate(data)
+
+    async def get_current_user(self, **kwargs: Any) -> GetCurrentUser:
+        query = gql(
+            """
+            query getCurrentUser {
+              userData {
+                currentUser {
+                  id
+                  name
+                  guilds {
+                    id
+                    name
+                    server {
+                      name
+                      region {
+                        name
+                      }
+                    }
+                  }
+                  characters {
+                    id
+                    name
+                    server {
+                      name
+                      region {
+                        name
+                      }
+                    }
+                    gameData
+                    classID
+                    raceID
+                    hidden
+                  }
+                  naDisplayName
+                  euDisplayName
+                }
+              }
+            }
+            """
+        )
+        variables: Dict[str, object] = {}
+        response = await self.execute(
+            query=query, operation_name="getCurrentUser", variables=variables, **kwargs
+        )
+        data = self.get_data(response)
+        return GetCurrentUser.model_validate(data)
+
+    async def get_user_data(self, **kwargs: Any) -> GetUserData:
+        query = gql(
+            """
+            query getUserData {
+              userData {
+                user(id: 1) {
+                  id
+                }
+              }
+            }
+            """
+        )
+        variables: Dict[str, object] = {}
+        response = await self.execute(
+            query=query, operation_name="getUserData", variables=variables, **kwargs
+        )
+        data = self.get_data(response)
+        return GetUserData.model_validate(data)

--- a/esologs/_generated/get_current_user.py
+++ b/esologs/_generated/get_current_user.py
@@ -1,0 +1,67 @@
+from typing import Any, List, Optional
+
+from pydantic import Field
+
+from .base_model import BaseModel
+
+
+class GetCurrentUser(BaseModel):
+    user_data: Optional["GetCurrentUserUserData"] = Field(alias="userData")
+
+
+class GetCurrentUserUserData(BaseModel):
+    current_user: Optional["GetCurrentUserUserDataCurrentUser"] = Field(
+        alias="currentUser"
+    )
+
+
+class GetCurrentUserUserDataCurrentUser(BaseModel):
+    id: int
+    name: str
+    guilds: Optional[List[Optional["GetCurrentUserUserDataCurrentUserGuilds"]]]
+    characters: Optional[List[Optional["GetCurrentUserUserDataCurrentUserCharacters"]]]
+    na_display_name: Optional[str] = Field(alias="naDisplayName")
+    eu_display_name: Optional[str] = Field(alias="euDisplayName")
+
+
+class GetCurrentUserUserDataCurrentUserGuilds(BaseModel):
+    id: int
+    name: str
+    server: "GetCurrentUserUserDataCurrentUserGuildsServer"
+
+
+class GetCurrentUserUserDataCurrentUserGuildsServer(BaseModel):
+    name: str
+    region: "GetCurrentUserUserDataCurrentUserGuildsServerRegion"
+
+
+class GetCurrentUserUserDataCurrentUserGuildsServerRegion(BaseModel):
+    name: str
+
+
+class GetCurrentUserUserDataCurrentUserCharacters(BaseModel):
+    id: int
+    name: str
+    server: "GetCurrentUserUserDataCurrentUserCharactersServer"
+    game_data: Optional[Any] = Field(alias="gameData")
+    class_id: int = Field(alias="classID")
+    race_id: int = Field(alias="raceID")
+    hidden: bool
+
+
+class GetCurrentUserUserDataCurrentUserCharactersServer(BaseModel):
+    name: str
+    region: "GetCurrentUserUserDataCurrentUserCharactersServerRegion"
+
+
+class GetCurrentUserUserDataCurrentUserCharactersServerRegion(BaseModel):
+    name: str
+
+
+GetCurrentUser.model_rebuild()
+GetCurrentUserUserData.model_rebuild()
+GetCurrentUserUserDataCurrentUser.model_rebuild()
+GetCurrentUserUserDataCurrentUserGuilds.model_rebuild()
+GetCurrentUserUserDataCurrentUserGuildsServer.model_rebuild()
+GetCurrentUserUserDataCurrentUserCharacters.model_rebuild()
+GetCurrentUserUserDataCurrentUserCharactersServer.model_rebuild()

--- a/esologs/_generated/get_user_by_id.py
+++ b/esologs/_generated/get_user_by_id.py
@@ -1,0 +1,65 @@
+from typing import Any, List, Optional
+
+from pydantic import Field
+
+from .base_model import BaseModel
+
+
+class GetUserById(BaseModel):
+    user_data: Optional["GetUserByIdUserData"] = Field(alias="userData")
+
+
+class GetUserByIdUserData(BaseModel):
+    user: Optional["GetUserByIdUserDataUser"]
+
+
+class GetUserByIdUserDataUser(BaseModel):
+    id: int
+    name: str
+    guilds: Optional[List[Optional["GetUserByIdUserDataUserGuilds"]]]
+    characters: Optional[List[Optional["GetUserByIdUserDataUserCharacters"]]]
+    na_display_name: Optional[str] = Field(alias="naDisplayName")
+    eu_display_name: Optional[str] = Field(alias="euDisplayName")
+
+
+class GetUserByIdUserDataUserGuilds(BaseModel):
+    id: int
+    name: str
+    server: "GetUserByIdUserDataUserGuildsServer"
+
+
+class GetUserByIdUserDataUserGuildsServer(BaseModel):
+    name: str
+    region: "GetUserByIdUserDataUserGuildsServerRegion"
+
+
+class GetUserByIdUserDataUserGuildsServerRegion(BaseModel):
+    name: str
+
+
+class GetUserByIdUserDataUserCharacters(BaseModel):
+    id: int
+    name: str
+    server: "GetUserByIdUserDataUserCharactersServer"
+    game_data: Optional[Any] = Field(alias="gameData")
+    class_id: int = Field(alias="classID")
+    race_id: int = Field(alias="raceID")
+    hidden: bool
+
+
+class GetUserByIdUserDataUserCharactersServer(BaseModel):
+    name: str
+    region: "GetUserByIdUserDataUserCharactersServerRegion"
+
+
+class GetUserByIdUserDataUserCharactersServerRegion(BaseModel):
+    name: str
+
+
+GetUserById.model_rebuild()
+GetUserByIdUserData.model_rebuild()
+GetUserByIdUserDataUser.model_rebuild()
+GetUserByIdUserDataUserGuilds.model_rebuild()
+GetUserByIdUserDataUserGuildsServer.model_rebuild()
+GetUserByIdUserDataUserCharacters.model_rebuild()
+GetUserByIdUserDataUserCharactersServer.model_rebuild()

--- a/esologs/_generated/get_user_data.py
+++ b/esologs/_generated/get_user_data.py
@@ -1,0 +1,21 @@
+from typing import Optional
+
+from pydantic import Field
+
+from .base_model import BaseModel
+
+
+class GetUserData(BaseModel):
+    user_data: Optional["GetUserDataUserData"] = Field(alias="userData")
+
+
+class GetUserDataUserData(BaseModel):
+    user: Optional["GetUserDataUserDataUser"]
+
+
+class GetUserDataUserDataUser(BaseModel):
+    id: int
+
+
+GetUserData.model_rebuild()
+GetUserDataUserData.model_rebuild()

--- a/esologs/client.py
+++ b/esologs/client.py
@@ -1,20 +1,21 @@
-"""
-ESO Logs API Client.
+"""ESO Logs API Client - the primary interface for interacting with the ESO Logs GraphQL API.
 
-This is the main client class that combines all API functionality through mixins.
+This client provides comprehensive access to ESO Logs data including game data,
+character information, guild data, reports, rankings, and more.
 """
 
-from typing import Any
+import warnings
+from typing import Any, Optional, Union
 
 from esologs._generated.async_base_client import AsyncBaseClient
-from esologs.mixins import (
-    CharacterMixin,
-    GameDataMixin,
-    GuildMixin,
-    ProgressRaceMixin,
-    ReportMixin,
-    WorldDataMixin,
-)
+from esologs.mixins.character import CharacterMixin
+from esologs.mixins.game_data import GameDataMixin
+from esologs.mixins.guild import GuildMixin
+from esologs.mixins.progress_race import ProgressRaceMixin
+from esologs.mixins.report import ReportMixin
+from esologs.mixins.user import UserMixin
+from esologs.mixins.world_data import WorldDataMixin
+from esologs.user_auth import UserToken
 
 
 class Client(
@@ -25,38 +26,80 @@ class Client(
     GuildMixin,
     ReportMixin,
     ProgressRaceMixin,
+    UserMixin,
 ):
-    """
-    ESO Logs API Client.
+    """ESO Logs API Client with all available methods.
 
-    This client provides access to all ESO Logs API functionality through
-    a modular mixin-based architecture.
+    This client supports both client credentials (for most API methods) and
+    user authentication (for user-specific data).
+
+    For user authentication, you can either:
+    1. Pass a UserToken to the constructor
+    2. Use the /api/v2/user endpoint for currentUser queries
 
     Example:
-        >>> import asyncio
-        >>> from esologs import Client
-        >>>
-        >>> async def main():
-        ...     async with Client(
-        ...         client_id="your_client_id",
-        ...         client_secret="your_client_secret"
-        ...     ) as client:
-        ...         # Get ability information
-        ...         ability = await client.get_ability(id=20301)
-        ...         # Access ability name: ability.game_data.ability.name
-        >>>
-        >>> asyncio.run(main())
+        # Client credentials (default)
+        async with Client(
+            url="https://www.esologs.com/api/v2/client",
+            headers={"Authorization": f"Bearer {client_token}"}
+        ) as client:
+            character = await client.get_character_by_id(id=12345)
+
+        # User authentication
+        async with Client(
+            url="https://www.esologs.com/api/v2/user",  # Note: /user endpoint
+            headers={"Authorization": f"Bearer {user_token}"}
+        ) as client:
+            current_user = await client.get_current_user()
     """
 
-    def __init__(self, **kwargs: Any) -> None:
-        """Initialize the ESO Logs client."""
-        super().__init__(**kwargs)
+    def __init__(
+        self,
+        url: str,
+        headers: Optional[dict] = None,
+        user_token: Optional[Union[str, UserToken]] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the ESO Logs client.
 
-    async def __aenter__(self) -> "Client":
-        """Async context manager entry."""
-        return self
+        Args:
+            url: GraphQL endpoint URL. Use /api/v2/client for client credentials
+                 or /api/v2/user for user authentication
+            headers: HTTP headers including Authorization
+            user_token: Optional UserToken object or access token string for user auth
+            **kwargs: Additional arguments passed to AsyncBaseClient
+        """
+        # Handle user token if provided
+        if user_token:
+            if isinstance(user_token, str):
+                # If string, assume it's an access token
+                headers = headers or {}
+                headers["Authorization"] = f"Bearer {user_token}"
+            elif isinstance(user_token, UserToken):
+                # If UserToken object, use its access token
+                headers = headers or {}
+                headers["Authorization"] = f"Bearer {user_token.access_token}"
 
-    async def __aexit__(self, *args: Any) -> None:
-        """Async context manager exit."""
-        # Use parent's __aexit__ which closes the http_client
-        await super().__aexit__(*args)
+                # Check if token is expired
+                if user_token.is_expired:
+                    warnings.warn(
+                        "UserToken appears to be expired. Consider refreshing it.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+
+        # Detect if using user endpoint and warn if no user token
+        if "/api/v2/user" in url and not user_token:
+            warnings.warn(
+                "Using /api/v2/user endpoint without user authentication. "
+                "Most queries will fail. Use /api/v2/client for client credentials.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        super().__init__(url=url, headers=headers, **kwargs)
+
+    @property
+    def is_user_authenticated(self) -> bool:
+        """Check if the client is configured for user authentication."""
+        return "/api/v2/user" in self.url

--- a/esologs/mixins/user.py
+++ b/esologs/mixins/user.py
@@ -1,0 +1,123 @@
+"""
+User data related methods for ESO Logs API client.
+
+This mixin provides access to user-specific data that requires OAuth2 user authentication.
+These methods require the "view-user-profile" scope and must be used with user tokens.
+"""
+
+from typing import TYPE_CHECKING, Any, Dict, Optional, Protocol
+
+from esologs._generated.get_current_user import GetCurrentUser
+from esologs._generated.get_user_by_id import GetUserById
+from esologs._generated.get_user_data import GetUserData
+from esologs.method_factory import create_complex_method, create_no_params_getter
+
+if TYPE_CHECKING:
+    import httpx
+
+
+class ClientProtocol(Protocol):
+    """Protocol for ESO Logs client methods needed by user data operations."""
+
+    async def execute(
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> "httpx.Response":
+        """Execute a GraphQL query."""
+        ...
+
+    def get_data(self, response: "httpx.Response") -> Dict[str, Any]:
+        """Extract data from GraphQL response."""
+        ...
+
+
+class UserMixin:
+    """Mixin class for user data-related operations.
+
+    Note: All methods in this mixin require OAuth2 user authentication with
+    the "view-user-profile" scope. They will not work with client credentials.
+
+    Additionally, the currentUser query requires using the /api/v2/user endpoint
+    instead of the standard /api/v2/client endpoint.
+    """
+
+    def __init_subclass__(cls, **kwargs: Any):
+        """Initialize the subclass with user data methods."""
+        super().__init_subclass__(**kwargs)
+        cls._register_user_methods()
+
+    @classmethod
+    def _register_user_methods(cls) -> None:
+        """Register all user data-related methods on the class."""
+
+        # get_user_by_id - use create_complex_method for custom parameter name
+        method = create_complex_method(
+            operation_name="getUserById",
+            return_type=GetUserById,
+            required_params={"user_id": int},
+            optional_params={},
+            param_mapping={"user_id": "userId"},
+        )
+        cls.get_user_by_id = method  # type: ignore[attr-defined]
+
+        # get_current_user - no params getter (requires user endpoint)
+        method = create_no_params_getter(
+            operation_name="getCurrentUser",
+            return_type=GetCurrentUser,
+        )
+        cls.get_current_user = method  # type: ignore[attr-defined]
+
+        # get_user_data - no params getter (for testing/validation)
+        method = create_no_params_getter(
+            operation_name="getUserData",
+            return_type=GetUserData,
+        )
+        cls.get_user_data = method  # type: ignore[attr-defined]
+
+        # Add method docstrings after methods are created
+        if hasattr(cls, "get_user_by_id"):
+            cls.get_user_by_id.__doc__ = """Get a specific user by their ID.
+
+    Requires OAuth2 user authentication with "view-user-profile" scope.
+
+    Args:
+        user_id: The ID of the user to retrieve
+
+    Returns:
+        GetUserById: User information including guilds and characters
+
+    Note:
+        The guilds and characters fields will only be populated if the
+        requesting user has the "view-user-profile" scope.
+    """
+
+        if hasattr(cls, "get_current_user"):
+            cls.get_current_user.__doc__ = """Get the currently authenticated user.
+
+    Requires OAuth2 user authentication with "view-user-profile" scope.
+    This method must be used with the /api/v2/user endpoint.
+
+    Returns:
+        GetCurrentUser: Current user information including guilds and characters
+
+    Note:
+        This method will not work with client credentials authentication.
+        It requires a user access token obtained through the OAuth2
+        Authorization Code flow.
+    """
+
+        if hasattr(cls, "get_user_data"):
+            cls.get_user_data.__doc__ = """Get the userData root object (primarily for testing).
+
+    Requires OAuth2 user authentication.
+
+    Returns:
+        GetUserData: The userData root object
+
+    Note:
+        This is primarily used for testing the user data API connection.
+        For practical use, prefer get_user_by_id or get_current_user.
+    """

--- a/esologs/queries.py
+++ b/esologs/queries.py
@@ -847,6 +847,91 @@ query getRateLimitData {
 }
 """
 
+# User Data Queries
+GET_USER_BY_ID = """
+query getUserById($userId: Int!) {
+  userData {
+    user(id: $userId) {
+      id
+      name
+      guilds {
+        id
+        name
+        server {
+          name
+          region {
+            name
+          }
+        }
+      }
+      characters {
+        id
+        name
+        server {
+          name
+          region {
+            name
+          }
+        }
+        gameData
+        classID
+        raceID
+        hidden
+      }
+      naDisplayName
+      euDisplayName
+    }
+  }
+}
+"""
+
+GET_CURRENT_USER = """
+query getCurrentUser {
+  userData {
+    currentUser {
+      id
+      name
+      guilds {
+        id
+        name
+        server {
+          name
+          region {
+            name
+          }
+        }
+      }
+      characters {
+        id
+        name
+        server {
+          name
+          region {
+            name
+          }
+        }
+        gameData
+        classID
+        raceID
+        hidden
+      }
+      naDisplayName
+      euDisplayName
+    }
+  }
+}
+"""
+
+GET_USER_DATA = """
+query getUserData {
+  userData {
+    user(id: 1) {
+      id
+    }
+  }
+}
+"""
+
 # Query mapping for easy access
 QUERIES = {
     # Game Data
@@ -892,4 +977,8 @@ QUERIES = {
     "getProgressRace": GET_PROGRESS_RACE,
     # Rate Limit
     "getRateLimitData": GET_RATE_LIMIT_DATA,
+    # User Data
+    "getUserById": GET_USER_BY_ID,
+    "getCurrentUser": GET_CURRENT_USER,
+    "getUserData": GET_USER_DATA,
 }

--- a/esologs/user_auth.py
+++ b/esologs/user_auth.py
@@ -1,0 +1,274 @@
+"""OAuth2 user authentication module for ESO Logs API.
+
+This module provides OAuth2 Authorization Code flow authentication for accessing
+user-specific ESO Logs API endpoints. It handles the full OAuth2 flow including
+authorization URL generation, code exchange, and token refresh.
+
+The Authorization Code flow is required for accessing user-specific data such as:
+- Current user profile (currentUser)
+- User guilds and characters
+- Any data requiring the "view-user-profile" scope
+"""
+
+import base64
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+from urllib.parse import urlencode
+
+import requests
+
+
+@dataclass
+class UserToken:
+    """Container for OAuth2 user tokens."""
+
+    access_token: str
+    token_type: str
+    expires_in: int
+    refresh_token: Optional[str] = None
+    scope: Optional[str] = None
+    created_at: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        """Set creation time if not provided."""
+        if self.created_at is None:
+            self.created_at = time.time()
+
+    @property
+    def is_expired(self) -> bool:
+        """Check if the token has expired."""
+        if self.expires_in is None or self.created_at is None:
+            return False
+        return time.time() > (
+            self.created_at + self.expires_in - 60
+        )  # 60 second buffer
+
+    @classmethod
+    def from_response(cls, response_data: Dict) -> "UserToken":
+        """Create UserToken from OAuth2 token response."""
+        return cls(
+            access_token=response_data["access_token"],
+            token_type=response_data.get("token_type", "Bearer"),
+            expires_in=response_data.get("expires_in", 3600),
+            refresh_token=response_data.get("refresh_token"),
+            scope=response_data.get("scope"),
+        )
+
+
+def generate_authorization_url(
+    client_id: str,
+    redirect_uri: str,
+    scopes: Optional[List[str]] = None,
+    state: Optional[str] = None,
+) -> str:
+    """Generate OAuth2 authorization URL for user authentication.
+
+    Args:
+        client_id: ESO Logs OAuth2 client ID
+        redirect_uri: Callback URL registered with your ESO Logs application
+        scopes: List of OAuth2 scopes (defaults to ["view-user-profile"])
+        state: Optional state parameter for CSRF protection
+
+    Returns:
+        Authorization URL to redirect the user to
+    """
+    base_url = "https://www.esologs.com/oauth/authorize"
+
+    if scopes is None:
+        scopes = ["view-user-profile"]
+
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "scope": " ".join(scopes),
+    }
+
+    if state:
+        params["state"] = state
+
+    return f"{base_url}?{urlencode(params)}"
+
+
+def exchange_authorization_code(
+    client_id: str,
+    client_secret: str,
+    code: str,
+    redirect_uri: str,
+) -> UserToken:
+    """Exchange authorization code for access token.
+
+    Args:
+        client_id: ESO Logs OAuth2 client ID
+        client_secret: ESO Logs OAuth2 client secret
+        code: Authorization code from callback
+        redirect_uri: Same redirect URI used in authorization request
+
+    Returns:
+        UserToken containing access token and refresh token
+
+    Raises:
+        Exception: If token exchange fails
+    """
+    token_url = "https://www.esologs.com/oauth/token"
+
+    # Prepare Basic auth header
+    auth_str = f"{client_id}:{client_secret}"
+    auth_bytes = auth_str.encode("utf-8")
+    auth_base64 = base64.b64encode(auth_bytes).decode("utf-8")
+
+    headers = {
+        "Authorization": f"Basic {auth_base64}",
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+    }
+
+    logging.debug("Exchanging authorization code for access token")
+
+    response = requests.post(token_url, headers=headers, data=data)
+
+    if response.status_code == 200:
+        token_data = response.json()
+        logging.debug("Successfully obtained user access token")
+        return UserToken.from_response(token_data)
+    else:
+        logging.error(f"Token exchange failed with status {response.status_code}")
+        # Sanitize error response to prevent credential exposure
+        error_msg = response.text
+        if "client" in error_msg.lower():
+            error_msg = "Authentication failed. Check client credentials."
+        raise Exception(
+            f"Token exchange failed with status {response.status_code}: {error_msg}"
+        )
+
+
+def refresh_access_token(
+    client_id: str,
+    client_secret: str,
+    refresh_token: str,
+) -> UserToken:
+    """Refresh an expired access token using refresh token.
+
+    Args:
+        client_id: ESO Logs OAuth2 client ID
+        client_secret: ESO Logs OAuth2 client secret
+        refresh_token: Refresh token from previous token response
+
+    Returns:
+        New UserToken with refreshed access token
+
+    Raises:
+        Exception: If token refresh fails
+    """
+    token_url = "https://www.esologs.com/oauth/token"
+
+    # Prepare Basic auth header
+    auth_str = f"{client_id}:{client_secret}"
+    auth_bytes = auth_str.encode("utf-8")
+    auth_base64 = base64.b64encode(auth_bytes).decode("utf-8")
+
+    headers = {
+        "Authorization": f"Basic {auth_base64}",
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+
+    data = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+    }
+
+    logging.debug("Refreshing access token")
+
+    response = requests.post(token_url, headers=headers, data=data)
+
+    if response.status_code == 200:
+        token_data = response.json()
+        logging.debug("Successfully refreshed access token")
+        return UserToken.from_response(token_data)
+    else:
+        logging.error(f"Token refresh failed with status {response.status_code}")
+        raise Exception(
+            f"Token refresh failed with status {response.status_code}: {response.text}"
+        )
+
+
+def save_token_to_file(token: UserToken, filepath: str = ".esologs_token.json") -> None:
+    """Save user token to file for persistence.
+
+    Args:
+        token: UserToken to save
+        filepath: Path to save token file (default: .esologs_token.json)
+    """
+    token_data = {
+        "access_token": token.access_token,
+        "token_type": token.token_type,
+        "expires_in": token.expires_in,
+        "refresh_token": token.refresh_token,
+        "scope": token.scope,
+        "created_at": token.created_at,
+    }
+
+    with open(filepath, "w") as f:
+        json.dump(token_data, f, indent=2)
+
+    logging.info(f"Token saved to {filepath}")
+
+
+def load_token_from_file(filepath: str = ".esologs_token.json") -> Optional[UserToken]:
+    """Load user token from file.
+
+    Args:
+        filepath: Path to token file (default: .esologs_token.json)
+
+    Returns:
+        UserToken if file exists and is valid, None otherwise
+    """
+    try:
+        with open(filepath) as f:
+            token_data = json.load(f)
+
+        return UserToken(
+            access_token=token_data["access_token"],
+            token_type=token_data.get("token_type", "Bearer"),
+            expires_in=token_data.get("expires_in", 3600),
+            refresh_token=token_data.get("refresh_token"),
+            scope=token_data.get("scope"),
+            created_at=token_data.get("created_at", time.time()),
+        )
+    except (FileNotFoundError, json.JSONDecodeError, KeyError):
+        return None
+
+
+# Example usage for documentation
+if __name__ == "__main__":
+    # This example shows the OAuth2 flow
+
+    # Step 1: Generate authorization URL
+    auth_url = generate_authorization_url(
+        client_id="your_client_id",
+        redirect_uri="http://localhost:8000/callback",
+        scopes=["view-user-profile"],
+        state="random_state_string",
+    )
+
+    # Step 2: User authorizes and is redirected back with code
+    # Example callback: http://localhost:8000/callback?code=abc123&state=random_state_string
+
+    # Step 3: Exchange code for token
+    # token = exchange_authorization_code(
+    #     client_id="your_client_id",
+    #     client_secret="your_client_secret",
+    #     code="abc123",
+    #     redirect_uri="http://localhost:8000/callback"
+    # )
+
+    # Step 4: Use token for API requests
+    # Client will automatically handle user tokens

--- a/queries.graphql
+++ b/queries.graphql
@@ -917,3 +917,84 @@ query getProgressRace($guildID: Int, $zoneID: Int, $competitionID: Int, $difficu
     )
   }
 }
+
+# Get user by ID
+query getUserById($userId: Int!) {
+  userData {
+    user(id: $userId) {
+      id
+      name
+      guilds {
+        id
+        name
+        server {
+          name
+          region {
+            name
+          }
+        }
+      }
+      characters {
+        id
+        name
+        server {
+          name
+          region {
+            name
+          }
+        }
+        gameData
+        classID
+        raceID
+        hidden
+      }
+      naDisplayName
+      euDisplayName
+    }
+  }
+}
+
+# Get current authenticated user
+query getCurrentUser {
+  userData {
+    currentUser {
+      id
+      name
+      guilds {
+        id
+        name
+        server {
+          name
+          region {
+            name
+          }
+        }
+      }
+      characters {
+        id
+        name
+        server {
+          name
+          region {
+            name
+          }
+        }
+        gameData
+        classID
+        raceID
+        hidden
+      }
+      naDisplayName
+      euDisplayName
+    }
+  }
+}
+
+# Get user data root (for testing)
+query getUserData {
+  userData {
+    user(id: 1) {
+      id
+    }
+  }
+}

--- a/tests/integration/test_user_data.py
+++ b/tests/integration/test_user_data.py
@@ -1,0 +1,290 @@
+"""Integration tests for UserData API methods.
+
+Note: These tests mock the OAuth2 user authentication since we cannot
+perform real user authentication in automated tests.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from esologs._generated.exceptions import GraphQLClientGraphQLMultiError
+from esologs.client import Client
+
+
+class TestUserDataIntegration:
+    """Test UserData API integration.
+
+    These tests demonstrate how the UserData methods would work with
+    proper OAuth2 user authentication. In production, you would need
+    to obtain a user access token through the OAuth2 flow.
+    """
+
+    @pytest.fixture
+    async def mock_user_client(self):
+        """Create a mock client configured for user authentication."""
+        # In production, you would use a real user token obtained via OAuth2
+        mock_client = Client(
+            url="https://www.esologs.com/api/v2/user",
+            headers={"Authorization": "Bearer mock_user_token"},
+        )
+
+        # Mock the execute method to return fake user data
+        mock_client.execute = AsyncMock()
+        mock_client.get_data = lambda response: response
+
+        yield mock_client
+
+    @pytest.mark.asyncio
+    async def test_get_user_by_id_success(self, mock_user_client):
+        """Test successful user retrieval by ID."""
+        # Mock response data
+        mock_response = {
+            "userData": {
+                "user": {
+                    "id": 12345,
+                    "name": "MockUser",
+                    "guilds": [
+                        {
+                            "id": 100,
+                            "name": "Mock Guild",
+                            "server": {
+                                "name": "NA Megaserver",
+                                "region": {"name": "North America"},
+                            },
+                        }
+                    ],
+                    "characters": [
+                        {
+                            "id": 200,
+                            "name": "MockCharacter",
+                            "server": {
+                                "name": "NA Megaserver",
+                                "region": {"name": "North America"},
+                            },
+                            "gameData": None,
+                            "classID": 1,
+                            "raceID": 1,
+                            "hidden": False,
+                        }
+                    ],
+                    "naDisplayName": "@MockUser",
+                    "euDisplayName": None,
+                }
+            }
+        }
+
+        mock_user_client.execute.return_value = mock_response
+
+        # Make the API call
+        result = await mock_user_client.get_user_by_id(user_id=12345)
+
+        # Verify the result
+        assert result.user_data.user.id == 12345
+        assert result.user_data.user.name == "MockUser"
+        assert len(result.user_data.user.guilds) == 1
+        assert result.user_data.user.guilds[0].name == "Mock Guild"
+        assert len(result.user_data.user.characters) == 1
+        assert result.user_data.user.characters[0].name == "MockCharacter"
+        assert result.user_data.user.na_display_name == "@MockUser"
+
+    @pytest.mark.asyncio
+    async def test_get_user_by_id_not_found(self, mock_user_client):
+        """Test user not found scenario."""
+        # Mock response with null user
+        mock_response = {"userData": {"user": None}}
+
+        mock_user_client.execute.return_value = mock_response
+
+        # Make the API call
+        result = await mock_user_client.get_user_by_id(user_id=99999)
+
+        # Verify the result
+        assert result.user_data.user is None
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_success(self, mock_user_client):
+        """Test successful current user retrieval."""
+        # Mock response data
+        mock_response = {
+            "userData": {
+                "currentUser": {
+                    "id": 54321,
+                    "name": "CurrentMockUser",
+                    "guilds": [
+                        {
+                            "id": 101,
+                            "name": "Guild One",
+                            "server": {
+                                "name": "NA Megaserver",
+                                "region": {"name": "North America"},
+                            },
+                        },
+                        {
+                            "id": 102,
+                            "name": "Guild Two",
+                            "server": {
+                                "name": "EU Megaserver",
+                                "region": {"name": "Europe"},
+                            },
+                        },
+                    ],
+                    "characters": [],
+                    "naDisplayName": "@CurrentMockUser",
+                    "euDisplayName": "@CurrentMockUserEU",
+                }
+            }
+        }
+
+        mock_user_client.execute.return_value = mock_response
+
+        # Make the API call
+        result = await mock_user_client.get_current_user()
+
+        # Verify the result
+        assert result.user_data.current_user.id == 54321
+        assert result.user_data.current_user.name == "CurrentMockUser"
+        assert len(result.user_data.current_user.guilds) == 2
+        assert result.user_data.current_user.guilds[0].name == "Guild One"
+        assert result.user_data.current_user.guilds[1].name == "Guild Two"
+        assert result.user_data.current_user.na_display_name == "@CurrentMockUser"
+        assert result.user_data.current_user.eu_display_name == "@CurrentMockUserEU"
+
+    @pytest.mark.asyncio
+    async def test_get_current_user_no_auth(self, mock_user_client):
+        """Test current user query without proper authentication."""
+        # Mock an authentication error
+        mock_user_client.execute.side_effect = GraphQLClientGraphQLMultiError(
+            errors=[{"message": "Unauthorized: Invalid token"}], data=None
+        )
+
+        # Attempt to get current user
+        with pytest.raises(GraphQLClientGraphQLMultiError) as exc_info:
+            await mock_user_client.get_current_user()
+
+        assert "Unauthorized" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_get_user_data_basic(self, mock_user_client):
+        """Test basic userData query."""
+        # Mock response data
+        mock_response = {"userData": {"user": {"id": 1}}}
+
+        mock_user_client.execute.return_value = mock_response
+
+        # Make the API call
+        result = await mock_user_client.get_user_data()
+
+        # Verify the result
+        assert result.user_data.user.id == 1
+
+    @pytest.mark.asyncio
+    async def test_user_without_guilds_or_characters(self, mock_user_client):
+        """Test user with no guilds or characters."""
+        # Mock response data
+        mock_response = {
+            "userData": {
+                "user": {
+                    "id": 77777,
+                    "name": "NewUser",
+                    "guilds": [],
+                    "characters": [],
+                    "naDisplayName": "@NewUser",
+                    "euDisplayName": None,
+                }
+            }
+        }
+
+        mock_user_client.execute.return_value = mock_response
+
+        # Make the API call
+        result = await mock_user_client.get_user_by_id(user_id=77777)
+
+        # Verify the result
+        assert result.user_data.user.id == 77777
+        assert result.user_data.user.name == "NewUser"
+        assert len(result.user_data.user.guilds) == 0
+        assert len(result.user_data.user.characters) == 0
+
+    @pytest.mark.asyncio
+    async def test_scope_restricted_fields(self, mock_user_client):
+        """Test that scope-restricted fields may be None without proper scope."""
+        # Mock response with restricted fields as None
+        mock_response = {
+            "userData": {
+                "user": {
+                    "id": 88888,
+                    "name": "RestrictedUser",
+                    "guilds": None,  # Requires view-user-profile scope
+                    "characters": None,  # Requires view-user-profile scope
+                    "naDisplayName": "@RestrictedUser",
+                    "euDisplayName": None,
+                }
+            }
+        }
+
+        mock_user_client.execute.return_value = mock_response
+
+        # Make the API call
+        result = await mock_user_client.get_user_by_id(user_id=88888)
+
+        # Verify the result
+        assert result.user_data.user.id == 88888
+        assert result.user_data.user.name == "RestrictedUser"
+        assert result.user_data.user.guilds is None
+        assert result.user_data.user.characters is None
+        assert result.user_data.user.na_display_name == "@RestrictedUser"
+
+    def test_client_endpoint_detection(self):
+        """Test that client correctly identifies user endpoint."""
+        # User endpoint
+        user_client = Client(
+            url="https://www.esologs.com/api/v2/user", user_token="user_token"
+        )
+        assert user_client.is_user_authenticated is True
+
+        # Client endpoint
+        client_client = Client(
+            url="https://www.esologs.com/api/v2/client",
+            headers={"Authorization": "Bearer client_token"},
+        )
+        assert client_client.is_user_authenticated is False
+
+
+# Note: In a real application, you would need to:
+# 1. Implement a web server to handle OAuth2 callbacks
+# 2. Use generate_authorization_url() to create the auth URL
+# 3. Handle the callback and extract the authorization code
+# 4. Use exchange_authorization_code() to get the access token
+# 5. Use the access token with the /api/v2/user endpoint
+#
+# Example flow (not runnable in tests):
+#
+# from esologs.user_auth import generate_authorization_url, exchange_authorization_code
+#
+# # Step 1: Generate auth URL
+# auth_url = generate_authorization_url(
+#     client_id="your_client_id",
+#     redirect_uri="http://localhost:8000/callback",
+#     scopes=["view-user-profile"]
+# )
+# Visit: {auth_url}
+#
+# # Step 2: User authorizes and is redirected to callback
+# # Extract 'code' from callback URL parameters
+#
+# # Step 3: Exchange code for token
+# user_token = exchange_authorization_code(
+#     client_id="your_client_id",
+#     client_secret="your_client_secret",
+#     code="authorization_code_from_callback",
+#     redirect_uri="http://localhost:8000/callback"
+# )
+#
+# # Step 4: Use token with client
+# async with Client(
+#     url="https://www.esologs.com/api/v2/user",
+#     user_token=user_token
+# ) as client:
+#     current_user = await client.get_current_user()
+#     Logged in as: {current_user.user_data.current_user.name}

--- a/tests/unit/test_client_user_auth.py
+++ b/tests/unit/test_client_user_auth.py
@@ -1,0 +1,118 @@
+"""Unit tests for Client user authentication support."""
+
+from unittest.mock import patch
+
+import pytest
+
+from esologs.client import Client
+from esologs.user_auth import UserToken
+
+
+class TestClientUserAuth:
+    """Test Client's user authentication features."""
+
+    def test_client_with_string_token(self):
+        """Test creating client with string access token."""
+        token = "test_access_token_123"
+
+        client = Client(url="https://www.esologs.com/api/v2/user", user_token=token)
+
+        assert client.headers["Authorization"] == "Bearer test_access_token_123"
+        assert client.is_user_authenticated is True
+
+    def test_client_with_user_token_object(self):
+        """Test creating client with UserToken object."""
+        user_token = UserToken(
+            access_token="token_from_object",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="refresh_123",
+        )
+
+        client = Client(
+            url="https://www.esologs.com/api/v2/user", user_token=user_token
+        )
+
+        assert client.headers["Authorization"] == "Bearer token_from_object"
+        assert client.is_user_authenticated is True
+
+    def test_client_with_expired_token_warning(self):
+        """Test that expired token triggers warning."""
+        # Create expired token
+        expired_token = UserToken(
+            access_token="expired_token",
+            token_type="Bearer",
+            expires_in=3600,
+            created_at=0,  # Very old timestamp
+        )
+
+        with pytest.warns(UserWarning, match="UserToken appears to be expired"):
+            client = Client(
+                url="https://www.esologs.com/api/v2/user", user_token=expired_token
+            )
+
+        # Token is still set despite being expired
+        assert client.headers["Authorization"] == "Bearer expired_token"
+
+    def test_client_user_endpoint_without_token_warning(self):
+        """Test warning when using user endpoint without auth."""
+        with pytest.warns(
+            UserWarning, match="Using /api/v2/user endpoint without user authentication"
+        ):
+            client = Client(
+                url="https://www.esologs.com/api/v2/user",
+                headers={"Authorization": "Bearer client_token"},
+            )
+
+        assert client.is_user_authenticated is True
+
+    def test_client_endpoint_detection(self):
+        """Test endpoint type detection."""
+        # Client endpoint
+        client1 = Client(
+            url="https://www.esologs.com/api/v2/client",
+            headers={"Authorization": "Bearer token"},
+        )
+        assert client1.is_user_authenticated is False
+
+        # User endpoint
+        client2 = Client(
+            url="https://www.esologs.com/api/v2/user", user_token="user_token"
+        )
+        assert client2.is_user_authenticated is True
+
+    def test_client_preserves_existing_headers(self):
+        """Test that user token doesn't override other headers."""
+        headers = {"X-Custom-Header": "custom_value", "User-Agent": "Test/1.0"}
+
+        client = Client(
+            url="https://www.esologs.com/api/v2/user",
+            headers=headers,
+            user_token="test_token",
+        )
+
+        assert client.headers["Authorization"] == "Bearer test_token"
+        assert client.headers["X-Custom-Header"] == "custom_value"
+        assert client.headers["User-Agent"] == "Test/1.0"
+
+    def test_client_token_precedence(self):
+        """Test that user_token takes precedence over headers auth."""
+        client = Client(
+            url="https://www.esologs.com/api/v2/user",
+            headers={"Authorization": "Bearer old_token"},
+            user_token="new_token",
+        )
+
+        assert client.headers["Authorization"] == "Bearer new_token"
+
+    @patch("esologs.client.warnings")
+    def test_no_warnings_for_client_endpoint(self, mock_warnings):
+        """Test no warnings for normal client endpoint usage."""
+        client = Client(
+            url="https://www.esologs.com/api/v2/client",
+            headers={"Authorization": "Bearer client_token"},
+        )
+
+        # Should not have any warnings
+        mock_warnings.warn.assert_not_called()
+        assert client.is_user_authenticated is False

--- a/tests/unit/test_user_auth.py
+++ b/tests/unit/test_user_auth.py
@@ -1,0 +1,288 @@
+"""Unit tests for OAuth2 user authentication module."""
+
+import json
+import time
+
+import pytest
+import responses
+
+from esologs.user_auth import (
+    UserToken,
+    exchange_authorization_code,
+    generate_authorization_url,
+    load_token_from_file,
+    refresh_access_token,
+    save_token_to_file,
+)
+
+
+class TestUserToken:
+    """Test UserToken class functionality."""
+
+    def test_user_token_creation(self):
+        """Test creating a UserToken with all fields."""
+        token = UserToken(
+            access_token="test_access_token",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="test_refresh_token",
+            scope="view-user-profile",
+        )
+
+        assert token.access_token == "test_access_token"
+        assert token.token_type == "Bearer"
+        assert token.expires_in == 3600
+        assert token.refresh_token == "test_refresh_token"
+        assert token.scope == "view-user-profile"
+        assert token.created_at is not None
+
+    def test_user_token_from_response(self):
+        """Test creating UserToken from OAuth2 response."""
+        response_data = {
+            "access_token": "response_token",
+            "token_type": "Bearer",
+            "expires_in": 7200,
+            "refresh_token": "response_refresh",
+            "scope": "view-user-profile",
+        }
+
+        token = UserToken.from_response(response_data)
+
+        assert token.access_token == "response_token"
+        assert token.token_type == "Bearer"
+        assert token.expires_in == 7200
+        assert token.refresh_token == "response_refresh"
+        assert token.scope == "view-user-profile"
+
+    def test_token_expiration_check(self):
+        """Test token expiration checking."""
+        # Create expired token
+        expired_token = UserToken(
+            access_token="expired",
+            token_type="Bearer",
+            expires_in=3600,
+            created_at=time.time() - 4000,  # Created over an hour ago
+        )
+        assert expired_token.is_expired is True
+
+        # Create valid token
+        valid_token = UserToken(
+            access_token="valid",
+            token_type="Bearer",
+            expires_in=3600,
+            created_at=time.time() - 1000,  # Created less than an hour ago
+        )
+        assert valid_token.is_expired is False
+
+        # Token without expires_in
+        no_expiry_token = UserToken(
+            access_token="no_expiry",
+            token_type="Bearer",
+            expires_in=None,
+        )
+        assert no_expiry_token.is_expired is False
+
+
+class TestAuthorizationUrl:
+    """Test OAuth2 authorization URL generation."""
+
+    def test_basic_authorization_url(self):
+        """Test generating basic authorization URL."""
+        url = generate_authorization_url(
+            client_id="test_client_id",
+            redirect_uri="http://localhost:8000/callback",
+        )
+
+        assert "https://www.esologs.com/oauth/authorize" in url
+        assert "response_type=code" in url
+        assert "client_id=test_client_id" in url
+        assert "redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fcallback" in url
+        assert "scope=view-user-profile" in url
+
+    def test_authorization_url_with_custom_scopes(self):
+        """Test authorization URL with custom scopes."""
+        url = generate_authorization_url(
+            client_id="test_client_id",
+            redirect_uri="http://localhost:8000/callback",
+            scopes=["view-user-profile", "read-reports"],
+        )
+
+        assert "scope=view-user-profile+read-reports" in url
+
+    def test_authorization_url_with_state(self):
+        """Test authorization URL with state parameter."""
+        url = generate_authorization_url(
+            client_id="test_client_id",
+            redirect_uri="http://localhost:8000/callback",
+            state="random_state_123",
+        )
+
+        assert "state=random_state_123" in url
+
+
+class TestTokenExchange:
+    """Test OAuth2 token exchange functionality."""
+
+    @responses.activate
+    def test_successful_token_exchange(self):
+        """Test successful authorization code exchange."""
+        # Mock successful response
+        responses.add(
+            responses.POST,
+            "https://www.esologs.com/oauth/token",
+            json={
+                "access_token": "new_access_token",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "refresh_token": "new_refresh_token",
+                "scope": "view-user-profile",
+            },
+            status=200,
+        )
+
+        token = exchange_authorization_code(
+            client_id="test_client",
+            client_secret="test_secret",
+            code="auth_code_123",
+            redirect_uri="http://localhost:8000/callback",
+        )
+
+        assert token.access_token == "new_access_token"
+        assert token.refresh_token == "new_refresh_token"
+        assert token.scope == "view-user-profile"
+
+        # Verify request
+        assert len(responses.calls) == 1
+        request = responses.calls[0].request
+        assert request.headers["Authorization"].startswith("Basic ")
+        assert "grant_type=authorization_code" in request.body
+        assert "code=auth_code_123" in request.body
+
+    @responses.activate
+    def test_failed_token_exchange(self):
+        """Test failed authorization code exchange."""
+        # Mock error response
+        responses.add(
+            responses.POST,
+            "https://www.esologs.com/oauth/token",
+            json={"error": "invalid_grant"},
+            status=400,
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            exchange_authorization_code(
+                client_id="test_client",
+                client_secret="test_secret",
+                code="invalid_code",
+                redirect_uri="http://localhost:8000/callback",
+            )
+
+        assert "Token exchange failed" in str(exc_info.value)
+
+
+class TestTokenRefresh:
+    """Test OAuth2 token refresh functionality."""
+
+    @responses.activate
+    def test_successful_token_refresh(self):
+        """Test successful token refresh."""
+        # Mock successful response
+        responses.add(
+            responses.POST,
+            "https://www.esologs.com/oauth/token",
+            json={
+                "access_token": "refreshed_access_token",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "refresh_token": "new_refresh_token",
+            },
+            status=200,
+        )
+
+        token = refresh_access_token(
+            client_id="test_client",
+            client_secret="test_secret",
+            refresh_token="old_refresh_token",
+        )
+
+        assert token.access_token == "refreshed_access_token"
+        assert token.refresh_token == "new_refresh_token"
+
+        # Verify request
+        assert len(responses.calls) == 1
+        request = responses.calls[0].request
+        assert "grant_type=refresh_token" in request.body
+        assert "refresh_token=old_refresh_token" in request.body
+
+    @responses.activate
+    def test_failed_token_refresh(self):
+        """Test failed token refresh."""
+        # Mock error response
+        responses.add(
+            responses.POST,
+            "https://www.esologs.com/oauth/token",
+            json={"error": "invalid_refresh_token"},
+            status=400,
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            refresh_access_token(
+                client_id="test_client",
+                client_secret="test_secret",
+                refresh_token="invalid_refresh_token",
+            )
+
+        assert "Token refresh failed" in str(exc_info.value)
+
+
+class TestTokenPersistence:
+    """Test token save/load functionality."""
+
+    def test_save_and_load_token(self, tmp_path):
+        """Test saving and loading token from file."""
+        # Create token
+        original_token = UserToken(
+            access_token="persist_token",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="persist_refresh",
+            scope="view-user-profile",
+        )
+
+        # Save to file
+        token_file = tmp_path / "test_token.json"
+        save_token_to_file(original_token, str(token_file))
+
+        # Load from file
+        loaded_token = load_token_from_file(str(token_file))
+
+        assert loaded_token is not None
+        assert loaded_token.access_token == original_token.access_token
+        assert loaded_token.refresh_token == original_token.refresh_token
+        assert loaded_token.scope == original_token.scope
+        assert loaded_token.expires_in == original_token.expires_in
+
+    def test_load_nonexistent_token_file(self, tmp_path):
+        """Test loading from non-existent file returns None."""
+        token_file = tmp_path / "nonexistent.json"
+        token = load_token_from_file(str(token_file))
+        assert token is None
+
+    def test_load_invalid_token_file(self, tmp_path):
+        """Test loading from invalid JSON file returns None."""
+        token_file = tmp_path / "invalid.json"
+        token_file.write_text("invalid json content")
+
+        token = load_token_from_file(str(token_file))
+        assert token is None
+
+    def test_load_incomplete_token_file(self, tmp_path):
+        """Test loading from incomplete token file still works with defaults."""
+        token_file = tmp_path / "incomplete.json"
+        token_file.write_text(json.dumps({"access_token": "only_this"}))
+
+        token = load_token_from_file(str(token_file))
+        assert token is not None
+        assert token.access_token == "only_this"
+        assert token.token_type == "Bearer"  # default
+        assert token.expires_in == 3600  # default

--- a/tests/unit/test_user_mixin.py
+++ b/tests/unit/test_user_mixin.py
@@ -1,0 +1,175 @@
+"""Unit tests for UserMixin functionality."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from esologs._generated.get_current_user import GetCurrentUser
+from esologs._generated.get_user_by_id import GetUserById
+from esologs._generated.get_user_data import GetUserData
+from esologs.mixins.user import UserMixin
+
+
+class MockClient(UserMixin):
+    """Mock client that includes UserMixin."""
+
+    def __init__(self):
+        self.execute = AsyncMock()
+        self.get_data = Mock()
+
+
+class TestUserMixin:
+    """Test UserMixin methods."""
+
+    @pytest.fixture
+    def client(self):
+        """Create test client with UserMixin."""
+        return MockClient()
+
+    @pytest.mark.asyncio
+    async def test_get_user_by_id(self, client):
+        """Test get_user_by_id method."""
+        # Mock response
+        mock_response = Mock()
+        mock_data = {
+            "userData": {
+                "user": {
+                    "id": 12345,
+                    "name": "TestUser",
+                    "guilds": [
+                        {
+                            "id": 100,
+                            "name": "Test Guild",
+                            "server": {
+                                "name": "NA Megaserver",
+                                "region": {"name": "North America"},
+                            },
+                        }
+                    ],
+                    "characters": [
+                        {
+                            "id": 200,
+                            "name": "TestCharacter",
+                            "server": {
+                                "name": "NA Megaserver",
+                                "region": {"name": "North America"},
+                            },
+                            "gameData": {"some": "data"},
+                            "classID": 1,
+                            "raceID": 1,
+                            "hidden": False,
+                        }
+                    ],
+                    "naDisplayName": "@TestUser",
+                    "euDisplayName": None,
+                }
+            }
+        }
+
+        client.execute.return_value = mock_response
+        client.get_data.return_value = mock_data
+
+        # Call method
+        result = await client.get_user_by_id(user_id=12345)
+
+        # Verify call
+        client.execute.assert_called_once()
+        call_args = client.execute.call_args
+        assert "getUserById" in call_args.kwargs["operation_name"]
+        assert call_args.kwargs["variables"]["userId"] == 12345
+
+        # Verify result type
+        assert isinstance(result, GetUserById)
+        assert result.user_data.user.id == 12345
+        assert result.user_data.user.name == "TestUser"
+        assert len(result.user_data.user.guilds) == 1
+        assert result.user_data.user.guilds[0].name == "Test Guild"
+
+    @pytest.mark.asyncio
+    async def test_get_current_user(self, client):
+        """Test get_current_user method."""
+        # Mock response
+        mock_response = Mock()
+        mock_data = {
+            "userData": {
+                "currentUser": {
+                    "id": 54321,
+                    "name": "CurrentUser",
+                    "guilds": [],
+                    "characters": [],
+                    "naDisplayName": "@CurrentUser",
+                    "euDisplayName": "@CurrentUserEU",
+                }
+            }
+        }
+
+        client.execute.return_value = mock_response
+        client.get_data.return_value = mock_data
+
+        # Call method
+        result = await client.get_current_user()
+
+        # Verify call
+        client.execute.assert_called_once()
+        call_args = client.execute.call_args
+        assert "getCurrentUser" in call_args.kwargs["operation_name"]
+        assert call_args.kwargs["variables"] == {}
+
+        # Verify result type
+        assert isinstance(result, GetCurrentUser)
+        assert result.user_data.current_user.id == 54321
+        assert result.user_data.current_user.name == "CurrentUser"
+        assert result.user_data.current_user.na_display_name == "@CurrentUser"
+        assert result.user_data.current_user.eu_display_name == "@CurrentUserEU"
+
+    @pytest.mark.asyncio
+    async def test_get_user_data(self, client):
+        """Test get_user_data method."""
+        # Mock response
+        mock_response = Mock()
+        mock_data = {"userData": {"user": {"id": 1}}}
+
+        client.execute.return_value = mock_response
+        client.get_data.return_value = mock_data
+
+        # Call method
+        result = await client.get_user_data()
+
+        # Verify call
+        client.execute.assert_called_once()
+        call_args = client.execute.call_args
+        assert "getUserData" in call_args.kwargs["operation_name"]
+        assert call_args.kwargs["variables"] == {}
+
+        # Verify result type
+        assert isinstance(result, GetUserData)
+        assert result.user_data.user.id == 1
+
+    def test_method_registration(self):
+        """Test that methods are properly registered on the class."""
+        # Verify methods exist
+        assert hasattr(MockClient, "get_user_by_id")
+        assert hasattr(MockClient, "get_current_user")
+        assert hasattr(MockClient, "get_user_data")
+
+        # Verify they're callable
+        client = MockClient()
+        assert callable(client.get_user_by_id)
+        assert callable(client.get_current_user)
+        assert callable(client.get_user_data)
+
+    def test_method_docstrings(self):
+        """Test that methods have proper docstrings."""
+        client = MockClient()
+
+        # Check docstrings exist and contain key information
+        assert client.get_user_by_id.__doc__ is not None
+        assert "OAuth2 user authentication" in client.get_user_by_id.__doc__
+        assert "view-user-profile" in client.get_user_by_id.__doc__
+
+        assert client.get_current_user.__doc__ is not None
+        assert "/api/v2/user endpoint" in client.get_current_user.__doc__
+        assert "Authorization Code flow" in client.get_current_user.__doc__
+
+        assert client.get_user_data.__doc__ is not None
+        assert "testing" in client.get_user_data.__doc__


### PR DESCRIPTION
## Summary
- Implements the final 3 UserData API methods to achieve 100% API coverage
- Adds OAuth2 Authorization Code flow support for user authentication
- Includes comprehensive tests (27 unit tests, 8 integration tests)

## Key Changes
1. **OAuth2 User Authentication** (`user_auth.py`)
   - Authorization URL generation with scopes
   - Authorization code exchange for access tokens
   - Token refresh functionality
   - Token persistence utilities

2. **UserData API Methods** (`mixins/user.py`)
   - `get_user_by_id(user_id)` - Get specific user information
   - `get_current_user()` - Get authenticated user (requires /api/v2/user endpoint)
   - `get_user_data()` - Root userData query for testing

3. **Client Enhancement**
   - Support for both client credentials and user authentication
   - Automatic detection of endpoint type (/api/v2/client vs /api/v2/user)
   - Expired token warnings

4. **Test Coverage**
   - Unit tests for OAuth2 flows and token management
   - Integration tests demonstrating UserData API usage
   - Mock-based testing since real user auth not possible in CI

## API Coverage
With this PR, we achieve **100% API coverage** (42/42 methods):
- ✅ gameData - 13/13 methods
- ✅ characterData - 5/5 methods  
- ✅ reportData - 10/10 methods
- ✅ worldData - 4/4 methods
- ✅ rateLimitData - 1/1 method
- ✅ guildData - 5/5 methods
- ✅ progressRaceData - 1/1 method
- ✅ **userData - 3/3 methods** (NEW)

## Testing
All tests pass:
- 27 new unit tests
- 8 new integration tests
- Total: 404 tests (369 + 35 new)

## Usage Example
```python
# OAuth2 flow
auth_url = generate_authorization_url(
    client_id="your_client_id",
    redirect_uri="http://localhost:8000/callback",
    scopes=["view-user-profile"]
)

# After user authorizes, exchange code for token
user_token = exchange_authorization_code(
    client_id="your_client_id",
    client_secret="your_client_secret", 
    code="auth_code_from_callback",
    redirect_uri="http://localhost:8000/callback"
)

# Use with client
async with Client(
    url="https://www.esologs.com/api/v2/user",
    user_token=user_token
) as client:
    current_user = await client.get_current_user()
```

## Notes
- UserData methods require OAuth2 user authentication (not client credentials)
- The `currentUser` query only works with the /api/v2/user endpoint
- Guild and character data requires the "view-user-profile" scope