### PR TITLE
Fix API status checker false positives on ReadTheDocs

### DIFF
--- a/docs/javascripts/api-status-check.js
+++ b/docs/javascripts/api-status-check.js
@@ -142,7 +142,7 @@
             };
 
             // Add timestamp to prevent caching
-            img.src = `https://www.esologs.com/favicon.ico?t=${Date.now()}`;
+            img.src = `https://assets.rpglogs.com/img/eso/favicon.png?t=${Date.now()}`;
         });
     }
 


### PR DESCRIPTION
## Summary
- Fixed false positive "API down" banners appearing on ReadTheDocs builds
- Changed favicon URL from non-existent path to actual ESO Logs favicon

## Problem
The API status checker was trying to load `https://www.esologs.com/favicon.ico` which returns 404 (file doesn't exist). This caused the script to incorrectly show "API may be down" warnings on ReadTheDocs, while it worked locally because mkdocs serve was serving the local `docs/assets/favicon.ico` file.

## Solution
Updated the URL to use the actual ESO Logs favicon at `https://assets.rpglogs.com/img/eso/favicon.png` which:
- Returns 200 OK
- Has proper CORS headers (`Access-Control-Allow-Origin: *`)
- Will load successfully from any origin

## Testing
- Verified the new URL returns 200 with proper CORS headers
- Confirmed it's a valid PNG image
- The banner will now only show if the assets server is actually down

## Changes
- `docs/javascripts/api-status-check.js`: Changed favicon URL on line 145